### PR TITLE
Add Kubernetes Preview Deployment Workflow for PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -37,7 +37,14 @@ jobs:
               throw new Error(`Docker image ${repo}:${imageTag} not found after waiting.`);
             }
 
-      - name: Create Kubernetes Resources
+      - name: Create Namespace
+        uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        with:
+          args: create namespace killedbypr${{ github.event.pull_request.number }}
+          
+      - name: Deploy to Kubernetes
         run: |
           mkdir -p k8s
           cat <<EOF > k8s/deployment.yaml
@@ -108,7 +115,7 @@ jobs:
           EOF
 
       - name: Deploy to Kubernetes
-        uses: actions-hub/kubectl@master
+        uses: actions-hub/kubectl@v1.31.2
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
@@ -120,7 +127,7 @@ jobs:
 
     steps:
       - name: Cleanup Kubernetes Resources
-        uses: actions-hub/kubectl@master
+        uses: actions-hub/kubectl@v1.31.2
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,107 @@
+name: Deploy Preview to Kubernetes
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  deploy-preview:
+    if: ${{ github.event.action != 'closed' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Deploy to Kubernetes
+      uses: actions-hub/kubectl@master
+      env:
+        KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+      with:
+        args: |
+          apply -f - <<EOF
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: killedbypr${{ github.event.pull_request.number }}
+
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: killedby
+            namespace: killedbypr${{ github.event.pull_request.number }}
+          spec:
+            replicas: 3
+            selector:
+              matchLabels:
+                app: killedby
+            template:
+              metadata:
+                labels:
+                  app: killedby
+              spec:
+                containers:
+                - name: killedby
+                  image: bacherik/killedby:pr-${{ github.event.pull_request.number }}
+                  env:
+                  - name: GITHUB_USERNAME
+                    value: "bacherik"
+                  - name: GITHUB_REPOSITORY
+                    value: "killedby.json"
+                  ports:
+                  - containerPort: 8080
+
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: killedby
+            namespace: killedbypr${{ github.event.pull_request.number }}
+          spec:
+            selector:
+              app: killedby
+            ports:
+            - protocol: TCP
+              port: 80
+              targetPort: 8080
+
+          ---
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: killedby
+            namespace: killedbypr${{ github.event.pull_request.number }}
+            annotations:
+              cert-manager.io/cluster-issuer: "letsencrypt"
+              kubernetes.io/ingress.class: traefik
+              ingress.kubernetes.io/whitelist-source-range: "192.168.0.0/16"
+          spec:
+            tls:
+            - hosts:
+              - pr-${{ github.event.pull_request.number }}.killedby.bacherik.de
+              secretName: pr${{ github.event.pull_request.number }}-killedby-tls
+            rules:
+            - host: pr-${{ github.event.pull_request.number }}.killedby.bacherik.de
+              http:
+                paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: killedby
+                      port:
+                        number: 80
+          EOF
+
+  cleanup:
+    if: ${{ github.event.action == 'closed' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Cleanup Kubernetes Resources
+      uses: actions-hub/kubectl@master
+      env:
+        KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+      with:
+        args: delete namespace killedbypr${{ github.event.pull_request.number }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,105 +1,127 @@
 name: Deploy Preview to Kubernetes
 
 on:
-  workflow_run:
-    workflows: ["Build and Push Docker Image"]
+  pull_request:
     types:
-      - completed
+      - labeled
+      - closed
 
 jobs:
   deploy-preview:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.action == 'labeled' && github.event.label.name == 'deploy-preview' }}
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v4
+      - name: Checkout Code
+        uses: actions/checkout@v4
 
-    - name: Create Kubernetes Resources
-      run: |
-        mkdir -p k8s
-        cat <<EOF > k8s/deployment.yaml
-        apiVersion: apps/v1
-        kind: Deployment
-        metadata:
-          name: killedby
-          namespace: killedbypr${{ github.event.workflow_run.event.pull_request.number }}
-        spec:
-          replicas: 3
-          selector:
-            matchLabels:
-              app: killedby
-          template:
-            metadata:
-              labels:
+      - name: Wait for Image Build
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const imageTag = `pr-${prNumber}`;
+            const repo = 'bacherik/killedby';
+            let imageExists = false;
+
+            for (let i = 0; i < 30; i++) { // Retry for up to 5 minutes
+              const res = await fetch(`https://hub.docker.com/v2/repositories/${repo}/tags/${imageTag}/`);
+              if (res.status === 200) {
+                imageExists = true;
+                break;
+              }
+              await new Promise(resolve => setTimeout(resolve, 10000)); // Wait 10 seconds
+            }
+
+            if (!imageExists) {
+              throw new Error(`Docker image ${repo}:${imageTag} not found after waiting.`);
+            }
+
+      - name: Create Kubernetes Resources
+        run: |
+          mkdir -p k8s
+          cat <<EOF > k8s/deployment.yaml
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: killedby
+            namespace: killedbypr${{ github.event.pull_request.number }}
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
                 app: killedby
-            spec:
-              containers:
-              - name: killedby
-                image: bacherik/killedby:pr-${{ github.event.workflow_run.event.pull_request.number }}
-                env:
-                - name: GITHUB_USERNAME
-                  value: "bacherik"
-                - name: GITHUB_REPOSITORY
-                  value: "killedby.json"
-                ports:
-                - containerPort: 8080
-        ---
-        apiVersion: v1
-        kind: Service
-        metadata:
-          name: killedby
-          namespace: killedbypr${{ github.event.workflow_run.event.pull_request.number }}
-        spec:
-          selector:
-            app: killedby
-          ports:
-          - protocol: TCP
-            port: 80
-            targetPort: 8080
-        ---
-        apiVersion: networking.k8s.io/v1
-        kind: Ingress
-        metadata:
-          name: killedby
-          namespace: killedbypr${{ github.event.workflow_run.event.pull_request.number }}
-          annotations:
-            cert-manager.io/cluster-issuer: "letsencrypt"
-            kubernetes.io/ingress.class: traefik
-            ingress.kubernetes.io/whitelist-source-range: "192.168.0.0/16"
-        spec:
-          tls:
-          - hosts:
-            - pr-${{ github.event.workflow_run.event.pull_request.number }}.killedby.bacherik.de
-            secretName: pr${{ github.event.workflow_run.event.pull_request.number }}-killedby-tls
-          rules:
-          - host: pr-${{ github.event.workflow_run.event.pull_request.number }}.killedby.bacherik.de
-            http:
-              paths:
-              - path: /
-                pathType: Prefix
-                backend:
-                  service:
-                    name: killedby
-                    port:
-                      number: 80
-        EOF
+            template:
+              metadata:
+                labels:
+                  app: killedby
+              spec:
+                containers:
+                - name: killedby
+                  image: bacherik/killedby:pr-${{ github.event.pull_request.number }}
+                  env:
+                  - name: GITHUB_USERNAME
+                    value: "bacherik"
+                  - name: GITHUB_REPOSITORY
+                    value: "killedby.json"
+                  ports:
+                  - containerPort: 8080
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: killedby
+            namespace: killedbypr${{ github.event.pull_request.number }}
+          spec:
+            selector:
+              app: killedby
+            ports:
+            - protocol: TCP
+              port: 80
+              targetPort: 8080
+          ---
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: killedby
+            namespace: killedbypr${{ github.event.pull_request.number }}
+            annotations:
+              cert-manager.io/cluster-issuer: "letsencrypt"
+              kubernetes.io/ingress.class: traefik
+              ingress.kubernetes.io/whitelist-source-range: "192.168.0.0/16"
+          spec:
+            tls:
+            - hosts:
+              - pr-${{ github.event.pull_request.number }}.killedby.bacherik.de
+              secretName: pr${{ github.event.pull_request.number }}-killedby-tls
+            rules:
+            - host: pr-${{ github.event.pull_request.number }}.killedby.bacherik.de
+              http:
+                paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: killedby
+                      port:
+                        number: 80
+          EOF
 
-    - name: Deploy to Kubernetes
-      uses: actions-hub/kubectl@master
-      env:
-        KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-      with:
-        args: apply -f k8s/
+      - name: Deploy to Kubernetes
+        uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        with:
+          args: apply -f k8s/
 
   cleanup:
-    if: ${{ github.event.workflow_run.event.action == 'closed' }}
+    if: ${{ github.event.action == 'closed' }}
     runs-on: ubuntu-latest
 
     steps:
-    - name: Cleanup Kubernetes Resources
-      uses: actions-hub/kubectl@v1.31.2
-      env:
-        KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-      with:
-        args: delete namespace killedbypr${{ github.event.workflow_run.event.pull_request.number }}
+      - name: Cleanup Kubernetes Resources
+        uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        with:
+          args: delete namespace killedbypr${{ github.event.pull_request.number }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,107 +1,105 @@
 name: Deploy Preview to Kubernetes
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
+  workflow_run:
+    workflows: ["Build and Push Docker Image"]
+    types:
+      - completed
 
 jobs:
   deploy-preview:
-    if: ${{ github.event.action != 'closed' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
 
+    - name: Create Kubernetes Resources
+      run: |
+        mkdir -p k8s
+        cat <<EOF > k8s/deployment.yaml
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: killedby
+          namespace: killedbypr${{ github.event.workflow_run.event.pull_request.number }}
+        spec:
+          replicas: 3
+          selector:
+            matchLabels:
+              app: killedby
+          template:
+            metadata:
+              labels:
+                app: killedby
+            spec:
+              containers:
+              - name: killedby
+                image: bacherik/killedby:pr-${{ github.event.workflow_run.event.pull_request.number }}
+                env:
+                - name: GITHUB_USERNAME
+                  value: "bacherik"
+                - name: GITHUB_REPOSITORY
+                  value: "killedby.json"
+                ports:
+                - containerPort: 8080
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: killedby
+          namespace: killedbypr${{ github.event.workflow_run.event.pull_request.number }}
+        spec:
+          selector:
+            app: killedby
+          ports:
+          - protocol: TCP
+            port: 80
+            targetPort: 8080
+        ---
+        apiVersion: networking.k8s.io/v1
+        kind: Ingress
+        metadata:
+          name: killedby
+          namespace: killedbypr${{ github.event.workflow_run.event.pull_request.number }}
+          annotations:
+            cert-manager.io/cluster-issuer: "letsencrypt"
+            kubernetes.io/ingress.class: traefik
+            ingress.kubernetes.io/whitelist-source-range: "192.168.0.0/16"
+        spec:
+          tls:
+          - hosts:
+            - pr-${{ github.event.workflow_run.event.pull_request.number }}.killedby.bacherik.de
+            secretName: pr${{ github.event.workflow_run.event.pull_request.number }}-killedby-tls
+          rules:
+          - host: pr-${{ github.event.workflow_run.event.pull_request.number }}.killedby.bacherik.de
+            http:
+              paths:
+              - path: /
+                pathType: Prefix
+                backend:
+                  service:
+                    name: killedby
+                    port:
+                      number: 80
+        EOF
+
     - name: Deploy to Kubernetes
       uses: actions-hub/kubectl@master
       env:
         KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
       with:
-        args: |
-          apply -f - <<EOF
-          apiVersion: v1
-          kind: Namespace
-          metadata:
-            name: killedbypr${{ github.event.pull_request.number }}
-
-          ---
-          apiVersion: apps/v1
-          kind: Deployment
-          metadata:
-            name: killedby
-            namespace: killedbypr${{ github.event.pull_request.number }}
-          spec:
-            replicas: 3
-            selector:
-              matchLabels:
-                app: killedby
-            template:
-              metadata:
-                labels:
-                  app: killedby
-              spec:
-                containers:
-                - name: killedby
-                  image: bacherik/killedby:pr-${{ github.event.pull_request.number }}
-                  env:
-                  - name: GITHUB_USERNAME
-                    value: "bacherik"
-                  - name: GITHUB_REPOSITORY
-                    value: "killedby.json"
-                  ports:
-                  - containerPort: 8080
-
-          ---
-          apiVersion: v1
-          kind: Service
-          metadata:
-            name: killedby
-            namespace: killedbypr${{ github.event.pull_request.number }}
-          spec:
-            selector:
-              app: killedby
-            ports:
-            - protocol: TCP
-              port: 80
-              targetPort: 8080
-
-          ---
-          apiVersion: networking.k8s.io/v1
-          kind: Ingress
-          metadata:
-            name: killedby
-            namespace: killedbypr${{ github.event.pull_request.number }}
-            annotations:
-              cert-manager.io/cluster-issuer: "letsencrypt"
-              kubernetes.io/ingress.class: traefik
-              ingress.kubernetes.io/whitelist-source-range: "192.168.0.0/16"
-          spec:
-            tls:
-            - hosts:
-              - pr-${{ github.event.pull_request.number }}.killedby.bacherik.de
-              secretName: pr${{ github.event.pull_request.number }}-killedby-tls
-            rules:
-            - host: pr-${{ github.event.pull_request.number }}.killedby.bacherik.de
-              http:
-                paths:
-                - path: /
-                  pathType: Prefix
-                  backend:
-                    service:
-                      name: killedby
-                      port:
-                        number: 80
-          EOF
+        args: apply -f k8s/
 
   cleanup:
-    if: ${{ github.event.action == 'closed' }}
+    if: ${{ github.event.workflow_run.event.action == 'closed' }}
     runs-on: ubuntu-latest
 
     steps:
     - name: Cleanup Kubernetes Resources
-      uses: actions-hub/kubectl@master
+      uses: actions-hub/kubectl@v1.31.2
       env:
         KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
       with:
-        args: delete namespace killedbypr${{ github.event.pull_request.number }}
+        args: delete namespace killedbypr${{ github.event.workflow_run.event.pull_request.number }}


### PR DESCRIPTION
### Add Kubernetes Preview Deployment Workflow for PRs

#### Summary
This pull request introduces a GitHub Actions workflow that allows the deployment of a Kubernetes preview environment for each pull request. Deployment is initiated manually by team members with merge permissions by adding a `deploy-preview` label to the pull request.

#### Key Features
1. **Manual Deployment Trigger**:
   - The deployment is initiated when the `deploy-preview` label is added to a pull request.
   - Only team members with label management permissions (e.g., those with merge rights) can trigger the deployment.

2. **Namespace Isolation**:
   - Each pull request deployment is created in its own dedicated Kubernetes namespace (e.g., `killedbypr<PR_NUMBER>`), ensuring resource isolation and preventing conflicts.

3. **Dynamic Deployment**:
   - The application is deployed using an image tagged with the pull request number (`pr-<PR_NUMBER>`).
   - A unique Ingress route is created for the preview environment, accessible via:
     `https://pr-<PR_NUMBER>.killedby.bacherik.de`.

4. **Automatic Cleanup**:
   - When the pull request is closed, the associated Kubernetes namespace and resources are automatically deleted.

5. **Docker Image Build Validation**:
   - The workflow waits for the corresponding Docker image to be built and pushed successfully to the Docker registry before proceeding with the deployment.

#### Workflow Overview
The workflow includes the following jobs:

1. **Deploy Preview**:
   - Triggered by the addition of the `deploy-preview` label to a pull request.
   - Steps:
     - Waits for the Docker image (`bacherik/killedby:pr-<PR_NUMBER>`) to be available in the registry.
     - Creates a Kubernetes namespace specific to the pull request.
     - Deploys the application, service, and ingress resources to the cluster.

2. **Cleanup**:
   - Triggered when the pull request is closed.
   - Automatically deletes the Kubernetes namespace and all associated resources.

#### Secrets Required
The workflow relies on the following secret for Kubernetes cluster access:
1. **`KUBE_CONFIG`**: A base64-encoded Kubernetes configuration file.

#### Steps to Use
1. Ensure the workflow file is present in the `main` branch.
2. Add the `deploy-preview` label to a pull request to initiate the deployment.
3. Access the preview environment via the generated URL once deployment is complete.
4. When the pull request is closed, the environment is automatically cleaned up.

#### Notes
- The workflow uses the `actions-hub/kubectl` GitHub Action for managing Kubernetes resources.
- Ensure your Docker registry is properly configured to push and tag images with the pull request number.