### PR TITLE
Add Workflow to Deploy Main Branch to Kubernetes

### DIFF
--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -1,0 +1,103 @@
+name: Deploy Main to Kubernetes
+
+on:
+  workflow_run:
+    workflows:
+      - Build and Publish Image
+    types:
+      - completed
+
+jobs:
+  deploy-main:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Create Namespace (if not exists)
+        uses: actions-hub/kubectl@v1.31.3
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        with:
+          args: |
+            create namespace killedby-main || echo "Namespace already exists"
+
+      - name: Deploy to Kubernetes
+        run: |
+          mkdir -p k8s
+          cat <<EOF > k8s/deployment.yaml
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: killedby-latest
+            namespace: killedby-latest
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: killedby-latest
+            template:
+              metadata:
+                labels:
+                  app: killedby-latest
+              spec:
+                containers:
+                - name: killedby-latest
+                  image: bacherik/killedby:latest
+                  env:
+                  - name: GITHUB_USERNAME
+                    value: "bacherik"
+                  - name: GITHUB_REPOSITORY
+                    value: "killedby.json"
+                  - name: GITHUB_COMMIT_SHA
+                    value: ${{ env.COMMIT_SHA }}
+                  ports:
+                  - containerPort: 8080
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: killedby-latest
+            namespace: killedby-latest
+          spec:
+            selector:
+              app: killedby-latest
+            ports:
+            - protocol: TCP
+              port: 80
+              targetPort: 8080
+          ---
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: killedby-latest
+            namespace: killedby-latest
+            annotations:
+              cert-manager.io/cluster-issuer: "letsencrypt"
+              kubernetes.io/ingress.class: traefik
+              ingress.kubernetes.io/whitelist-source-range: "192.168.0.0/16"
+          spec:
+            tls:
+            - hosts:
+              - latest.killedby.bacherik.de
+              secretName: killedby-latest-tls
+            rules:
+            - host: latest.killedby.bacherik.de
+              http:
+                paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: killedby-latest
+                      port:
+                        number: 80
+          EOF
+
+      - name: Deploy to Kubernetes
+        uses: actions-hub/kubectl@v1.31.3
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        with:
+          args: apply -f k8s/

--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -3,7 +3,7 @@ name: Deploy Main to Kubernetes
 on:
   workflow_run:
     workflows:
-      - Build and Publish Image
+      - Build and Push Docker Image
     types:
       - completed
 
@@ -21,7 +21,7 @@ jobs:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
           args: |
-            create namespace killedby-main || echo "Namespace already exists"
+            create namespace killedby-latest || echo "Namespace already exists"
 
       - name: Deploy to Kubernetes
         run: |


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow, `Deploy Main to Kubernetes`, that automatically deploys the main branch to a Kubernetes cluster upon the successful completion of the `Build and Push Docker Image` workflow. The deployment includes a namespace, deployment, service, and ingress configuration tailored for `killedby-latest`.

---

#### **Key Changes**
1. **Workflow Trigger**:  
   - Triggered on completion of the `Build and Push Docker Image` workflow.

2. **Namespace Management**:  
   - Ensures the `killedby-latest` namespace is created if it doesn't already exist.

3. **Kubernetes Configuration**:  
   - Automatically generates a `deployment.yaml` file in the `k8s` directory containing:
     - **Deployment**:
       - Deploys a single replica of the container image `bacherik/killedby:latest`.
       - Passes necessary environment variables, including GitHub metadata.
       - Exposes the container on port 8080.
     - **Service**:
       - Exposes the deployment via a ClusterIP service on port 80.
     - **Ingress**:
       - Configures an Ingress resource for external access using the hostname `latest.killedby.bacherik.de`.
       - Supports HTTPS using Let's Encrypt certificates via Cert-Manager.
       - Limits access to the IP range `192.168.0.0/16`.

4. **Deployment Automation**:  
   - Utilizes `kubectl` to apply the generated configuration.

---

#### **Workflow Steps**
1. **Checkout Code**:  
   Ensures the repository is available in the workflow.

2. **Namespace Management**:  
   Creates the required namespace or confirms it already exists.

3. **Configuration Generation**:  
   Dynamically creates the Kubernetes deployment, service, and ingress configuration files.

4. **Deployment**:  
   Applies the configuration to the Kubernetes cluster using `kubectl`.