### PR TITLE
Fix #60

### DIFF
--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -15,13 +15,17 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Check if running in a pull request
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "Running in a pull request, aborting workflow." && exit 0
+
       - name: Create Namespace (if not exists)
         uses: actions-hub/kubectl@v1.31.3
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         with:
           args: |
-            create namespace killedby-latest || echo "Namespace already exists"
+            kubectl get namespace killedby-latest || kubectl create namespace killedby-latest
 
       - name: Deploy to Kubernetes
         run: |
@@ -45,6 +49,7 @@ jobs:
                 containers:
                 - name: killedby-latest
                   image: bacherik/killedby:latest
+                  imagePullPolicy: Always
                   env:
                   - name: GITHUB_USERNAME
                     value: "bacherik"


### PR DESCRIPTION
Fixes #60

Update the `Deploy Main to Kubernetes` workflow to address deployment issues.

* **Namespace Creation**: Modify the `Create Namespace` step to use `kubectl get namespace killedby-latest || kubectl create namespace killedby-latest` to prevent redundant namespace creation.
* **Pull Request Check**: Add a check to abort the workflow with success if it runs in a pull request.