### PR TITLE
Ensure Cleanup Only Runs if Deploy Preview Succeeds

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -125,6 +125,7 @@ jobs:
 
   cleanup:
     if: ${{ github.event.action == 'closed' }}
+    needs: deploy-preview
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
#### **Description:**
This PR updates the workflow to prevent the `cleanup` job from running unless the `deploy-preview` job has successfully deployed resources. 

#### **Key Changes:**
- Added `needs: deploy-preview` to the `cleanup` job.
- Ensures resources are only cleaned up when they were actually created.

#### **Why:**
This avoids unnecessary cleanup attempts and improves workflow reliability.

Let me know if further tweaks are needed! 